### PR TITLE
fix parsing and formatting of single-digit UTM zones in AWS bucket

### DIFF
--- a/src/main/java/ro/cs/products/sentinel2/SentinelProductDownloader.java
+++ b/src/main/java/ro/cs/products/sentinel2/SentinelProductDownloader.java
@@ -496,7 +496,8 @@ public class SentinelProductDownloader extends ProductDownloader<SentinelProduct
                 if (hasTiles) {
                     downloadFile(baseProductUrl + "inspire.xml", inspireFile);
                     downloadFile(baseProductUrl + "manifest.safe", manifestFile);
-                    downloadFile(baseProductUrl + "preview.png", previewFile);
+                    if (Constants.PSD_13.equals(productDescriptor.getVersion()))
+                        downloadFile(baseProductUrl + "preview.png", previewFile);
 
                     // rep_info folder and contents
                     Path repFolder = Utilities.ensureExists(rootPath.resolve("rep_info"));
@@ -695,6 +696,14 @@ public class SentinelProductDownloader extends ProductDownloader<SentinelProduct
         return productsUrl + descriptor.getProductRelativePath();
     }
 
+    private String tilePathToTileId(String tilePath) {
+        String[] tokens = tilePath.split(URL_SEPARATOR);
+        return String.format("%02d%s%s",
+                Integer.parseInt(tokens[1]),
+                tokens[2],
+                tokens[3]);
+    }
+
     private Map<String, String> getTileNames(JsonObject productInfo, List<String> metaTileNames, String psdVersion) {
         Map<String, String> ret = new HashMap<>();
         String dataTakeId = productInfo.getString("datatakeIdentifier");
@@ -703,8 +712,7 @@ public class SentinelProductDownloader extends ProductDownloader<SentinelProduct
         String skippedTiles = "";
         for (JsonObject result : tiles.getValuesAs(JsonObject.class)) {
             String tilePath = result.getString("path");
-            String[] tokens = tilePath.split(URL_SEPARATOR);
-            String tileId = tokens[1] + tokens[2] + tokens[3];
+            String tileId = tilePathToTileId(tilePath);
             if (!shouldFilterTiles || (filteredTiles.size() == 0 || filteredTiles.contains(tileId))) {
                 tileId = "T" + tileId;
                 String tileName = Utilities.find(metaTileNames, tileId, psdVersion);

--- a/src/main/java/ro/cs/products/sentinel2/amazon/AmazonSearch.java
+++ b/src/main/java/ro/cs/products/sentinel2/amazon/AmazonSearch.java
@@ -87,7 +87,7 @@ public class AmazonSearch extends AbstractSearch<ProductType> {
         int monthEnd = endDate.get(Calendar.MONTH) + 1;
         int dayEnd = endDate.get(Calendar.DAY_OF_MONTH);
         for (String tile : tiles) {
-            String utmCode = tile.substring(0, 2);
+            String utmCode = Integer.toString(Integer.parseInt(tile.substring(0, 2)));
             String latBand = tile.substring(2, 3);
             String square = tile.substring(3, 5);
             String tileUrl = this.url.toString() + utmCode + "/" + latBand + "/" + square + "/";


### PR DESCRIPTION
The sentinel2 AWS bucket doesn't use leading zeros for single-digit UTM zones; handle this in formatting and parsing the paths.

Also, don't pull preview.png in new format files, it doesn't exist there.